### PR TITLE
Nested stack changes based on tests

### DIFF
--- a/packages/amplify-cli/src/lib/migrate-project.js
+++ b/packages/amplify-cli/src/lib/migrate-project.js
@@ -115,9 +115,6 @@ function backup(amplifyDirPath, projectPath) {
 
   fs.copySync(amplifyDirPath, backupAmplifyDirPath);
 
-
-  console.log('backup done!');
-
   return backupAmplifyDirPath;
 }
 


### PR DESCRIPTION
*Issue #, if available:*

1. Sequentailly execute the migration commands in individually categories (async)

2. Update S3 template files for only resources created+updated

3. Add parameter in formNestedStacks function so that only that particular resource adds/injects the 'env' param. Could be enhanced further to accept a list instead os just one resource.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.