### PR TITLE
fix: corrected uploadKey construction for S3

### DIFF
--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -311,7 +311,7 @@ async function uploadDirectory(opts: UploadOptions, key: string = '') {
     const files = await readDir(opts.directory)
     for (const file of files) {
         const resourcePath = path.join(opts.directory, file)
-        const uploadKey = path.join(key, file)
+        const uploadKey = path.posix.join(key, file)
         const isDirectory = (await lstat(resourcePath)).isDirectory()
         if (isDirectory) {
             await uploadDirectory({ ...opts, directory: resourcePath }, uploadKey)


### PR DESCRIPTION
uploadKey was constructed with path.join(...) that uses '\\' on windows. 
S3 does not treat '\\' as a directory separator, hence switching to path.posix.join(...)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.